### PR TITLE
support Lingui v6 dependency ranges

### DIFF
--- a/.changeset/lingui-v6-compat.md
+++ b/.changeset/lingui-v6-compat.md
@@ -1,0 +1,5 @@
+---
+"esbuild-plugin-lingui-macro": patch
+---
+
+Widen Lingui dependency and peer ranges to support Lingui v6 while keeping v5 compatibility.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
-    "@lingui/babel-plugin-lingui-macro": "5.0.0-next.4 - 5"
+    "@lingui/babel-plugin-lingui-macro": "5.0.0-next.4 - 5 || 6.0.0-next.0 - 6"
   },
   "devDependencies": {
     "@types/babel__core": "^7.20.5",
@@ -45,8 +45,8 @@
     "@changesets/cli": "2.27.10"
   },
   "peerDependencies": {
-    "@lingui/cli": "5.0.0-next.4 - 5",
-    "@lingui/conf": "5.0.0-next.4 - 5",
+    "@lingui/cli": "5.0.0-next.4 - 5 || 6.0.0-next.0 - 6",
+    "@lingui/conf": "5.0.0-next.4 - 5 || 6.0.0-next.0 - 6",
     "esbuild": "*"
   },
   "repository": {


### PR DESCRIPTION
## What
- widen `@lingui/babel-plugin-lingui-macro` dependency range to support Lingui 5 and 6
- widen peer ranges for `@lingui/cli` and `@lingui/conf` to support Lingui 5 and 6
- add a patch changeset entry

## Why
Without the ranges set to v6, we saw v5 style transforms in id's. We saw this kind of difference with a direct transform comparison (fsOq/N vs fsOq_N). It seems Lingui v6 changed generated IDs to URL-safe base64 (+// -> -/_)?

Very excited about v6! 🙌