### PR TITLE
chore: sync pnpm lockfile specifiers with Lingui v6 ranges

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,13 +11,13 @@ importers:
         specifier: ^7.26.0
         version: 7.26.0
       "@lingui/babel-plugin-lingui-macro":
-        specifier: 5.0.0-next.4 - 5
+        specifier: 5.0.0-next.4 - 5 || 6.0.0-next.0 - 6
         version: 5.0.0-next.4(babel-plugin-macros@3.1.0)(typescript@5.6.3)
       "@lingui/cli":
-        specifier: 5.0.0-next.4 - 5
+        specifier: 5.0.0-next.4 - 5 || 6.0.0-next.0 - 6
         version: 5.0.0-next.4(typescript@5.6.3)
       "@lingui/conf":
-        specifier: 5.0.0-next.4 - 5
+        specifier: 5.0.0-next.4 - 5 || 6.0.0-next.0 - 6
         version: 5.0.0-next.4(typescript@5.6.3)
       esbuild:
         specifier: "*"


### PR DESCRIPTION
Fix release CI by syncing pnpm-lock.yaml with package.json after Lingui v6 range widening. Verified with CI=true pnpm install --frozen-lockfile and pnpm build.

I missed the lockfile update in #3, this should unblock release CI.